### PR TITLE
🐛 Fix season/episode data not displaying due to stale cache logic

### DIFF
--- a/frontend/src/routes/show/[id]/+page.svelte
+++ b/frontend/src/routes/show/[id]/+page.svelte
@@ -106,11 +106,15 @@
 
 			seasons = seasonsList;
 
-			// Load episodes for each season
-			for (const season of seasons) {
-				const episodesResponse = await api.search.getSeasonEpisodes(parseInt(id), season.season_number);
-				season.episodes = episodesResponse.episodes || [];
-			}
+			// Load episodes for all seasons in parallel (much faster!)
+			await Promise.all(
+				seasons.map(async (season) => {
+					const episodesResponse = await api.search.getSeasonEpisodes(parseInt(id), season.season_number);
+					season.episodes = episodesResponse.episodes || [];
+				})
+			);
+			// Trigger reactivity after all episodes loaded
+			seasons = seasons;
 		} catch (e) {
 			console.error('Failed to load seasons:', e);
 		} finally {


### PR DESCRIPTION
## Problem

When viewing TV show pages, the season and episode information would not appear for a long time (or at all), even though the data existed in the database. Users had to wait or refresh multiple times to see season information.

### Root Cause Analysis

The issue stemmed from an overly aggressive "freshness" check in the content caching strategy:

#### 1. Stale Data Returns Empty Arrays

In `content_repository.py`, the season/episode endpoints checked if content was "fresh" (synced within 7 days):

```python
# Before: Returns empty if content is stale
if self._is_fresh(content):
    # ... return seasons
return []  # Stale = empty!
```

This meant:
- Content older than 7 days → returned empty arrays
- Content with no `last_synced_at` (newly created) → treated as stale → returned empty

#### 2. Race Condition with Background Tasks

When viewing a new series:

```
Timeline:
0ms    → User requests /show/123
50ms   → Backend fetches series from API, returns immediately
100ms  → Backend queues background task to save full data
150ms  → Frontend requests /series/123/seasons
200ms  → Backend checks DB: content exists but last_synced_at = NULL
250ms  → _is_fresh() returns False → returns []
300ms  → Frontend shows empty seasons tab
...
5-15s  → Background task completes, sets last_synced_at
```

The user sees no seasons until they manually refresh after the background task completes.

#### 3. Sequential Episode Loading (Waterfall)

The frontend loaded episodes one season at a time:

```javascript
// Before: Sequential - each waits for previous
for (const season of seasons) {
    const episodes = await api.getSeasonEpisodes(id, season.number);
    season.episodes = episodes;
}
```

For a show with 10 seasons, this meant 10 sequential API calls, significantly increasing perceived load time.

## Solution

### Backend: Always Return Cached Data

Changed the caching strategy from "return empty if stale" to "return cached if available":

```python
# After: Always return cached data, background will refresh
stmt = select(Season).where(Season.content_id == content.id)
result = await self.db.execute(stmt)
seasons = result.scalars().all()
return [self._season_to_dict(season) for season in seasons]
```

**Rationale:** Stale data is better than no data. Background tasks still refresh the cache, so subsequent visits get fresh data. Users get an immediate response with whatever we have cached.

### Frontend: Parallel Episode Loading

Changed from sequential to parallel fetching:

```javascript
// After: Parallel - all at once
await Promise.all(
    seasons.map(async (season) => {
        const episodes = await api.getSeasonEpisodes(id, season.number);
        season.episodes = episodes;
    })
);
```

**Impact:** For a 10-season show, load time drops from ~10 sequential requests to ~1 parallel batch.

## Files Changed

| File | Changes |
|------|---------|
| `backend/app/services/content_repository.py` | Removed `_is_fresh()` check from `get_series_seasons()`, `get_series_episodes()`, and `get_season_episodes()` |
| `frontend/src/routes/show/[id]/+page.svelte` | Changed episode loading from sequential `for` loop to parallel `Promise.all()` |

## Caching Strategy (Updated)

| Scenario | Before | After |
|----------|--------|-------|
| Fresh content (< 7 days) | Return from DB | Return from DB |
| Stale content (> 7 days) | Return empty `[]` | Return from DB |
| New content (no sync timestamp) | Return empty `[]` | Return from DB |

Background sync tasks still run to refresh stale data, but users aren't blocked waiting for them.

## Test Plan

- [ ] View a TV show you haven't viewed before - seasons should appear immediately (or after a brief load)
- [ ] View a TV show you viewed > 7 days ago - seasons should appear immediately
- [ ] Expand a season - episodes should load quickly (parallel fetching)
- [ ] Check network tab - episode requests should fire in parallel, not sequentially