### PR TITLE
Add feedback system and recommendation cards

### DIFF
--- a/backend/app/schemas/swanson.py
+++ b/backend/app/schemas/swanson.py
@@ -1,6 +1,6 @@
 """Swanson AI recommendation schemas."""
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -15,6 +15,14 @@ class SearchResult(BaseModel):
     genres: Optional[list[str]] = None
 
 
+class FeedbackItem(BaseModel):
+    """User feedback on a recommendation."""
+
+    name: str
+    type: str
+    rating: Literal["dislike", "like", "love"]
+
+
 class RecommendRequest(BaseModel):
     """Request for AI recommendation."""
 
@@ -22,6 +30,14 @@ class RecommendRequest(BaseModel):
     search_results: list[SearchResult] = Field(
         default_factory=list,
         description="Current search results to consider",
+    )
+    feedback: list[FeedbackItem] = Field(
+        default_factory=list,
+        description="User feedback on previous recommendations",
+    )
+    previous_recommendations: list[str] = Field(
+        default_factory=list,
+        description="Titles already recommended in this session",
     )
 
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -217,6 +217,12 @@ export const api = {
 				year?: number;
 				genres?: string[];
 			}>;
+			feedback?: Array<{
+				name: string;
+				type: string;
+				rating: 'dislike' | 'like' | 'love';
+			}>;
+			previous_recommendations?: string[];
 		}) => {
 			return request('/swanson/recommend', {
 				method: 'POST',
@@ -234,6 +240,12 @@ export const api = {
 				year?: number;
 				genres?: string[];
 			}>;
+			feedback?: Array<{
+				name: string;
+				type: string;
+				rating: 'dislike' | 'like' | 'love';
+			}>;
+			previous_recommendations?: string[];
 		}): AsyncGenerator<string, void, unknown> {
 			console.log('[API] stream() called with prompt:', data.prompt.substring(0, 50));
 			const authState = get(auth);

--- a/frontend/src/lib/stores/swanson.ts
+++ b/frontend/src/lib/stores/swanson.ts
@@ -1,4 +1,6 @@
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
+
+export type Rating = 'dislike' | 'like' | 'love';
 
 export interface SearchResult {
 	id: number;
@@ -6,6 +8,13 @@ export interface SearchResult {
 	type: string;
 	year?: number;
 	image?: string;
+	rating?: Rating;
+}
+
+export interface FeedbackItem {
+	name: string;
+	type: string;
+	rating: Rating;
 }
 
 export interface Message {
@@ -35,4 +44,42 @@ export function parseTitles(content: string): { cleanContent: string; titles: st
 		return { cleanContent, titles };
 	}
 	return { cleanContent: content, titles: [] };
+}
+
+// Collect all feedback from messages
+export function collectFeedback(): FeedbackItem[] {
+	const messages = get(swansonMessages);
+	const feedback: FeedbackItem[] = [];
+
+	for (const msg of messages) {
+		if (msg.role === 'swanson' && msg.recommendations) {
+			for (const rec of msg.recommendations) {
+				if (rec.rating) {
+					feedback.push({
+						name: rec.name,
+						type: rec.type,
+						rating: rec.rating
+					});
+				}
+			}
+		}
+	}
+
+	return feedback;
+}
+
+// Collect all previously recommended titles
+export function collectPreviousRecommendations(): string[] {
+	const messages = get(swansonMessages);
+	const titles: string[] = [];
+
+	for (const msg of messages) {
+		if (msg.role === 'swanson' && msg.recommendations) {
+			for (const rec of msg.recommendations) {
+				titles.push(rec.name);
+			}
+		}
+	}
+
+	return titles;
 }


### PR DESCRIPTION
## Summary

- Add clickable recommendation cards below Swanson responses (up to 5)
- Add feedback icons (thumbs-down/thumbs-up/star) for rating recommendations
- Track user feedback to refine subsequent prompts
- Prevent duplicate recommendations within a session

## Features

- **Recommendation Cards** - Parse TITLES from LLM response, search API, display clickable cards with posters
- **Feedback System** - Rate recommendations as dislike/like/love
- **Prompt Refinement** - Feedback sent with next message: "Very interested in...", "Not interested in..."
- **No Repeats** - Previously recommended titles tracked and excluded

## Test plan

- [ ] Get initial recommendations from Swanson
- [ ] Click feedback icons on recommendation cards
- [ ] Send follow-up message like "More like that"
- [ ] Verify new recommendations differ and respect feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)