### PR TITLE
Add season sync status indicator

### DIFF
--- a/backend/alembic/versions/c8d1e2f3a4b5_add_sync_task_id_to_content.py
+++ b/backend/alembic/versions/c8d1e2f3a4b5_add_sync_task_id_to_content.py
@@ -1,0 +1,29 @@
+"""Add sync_task_id to content
+
+Revision ID: c8d1e2f3a4b5
+Revises: b2f4a7c83d91
+Create Date: 2026-03-03 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c8d1e2f3a4b5'
+down_revision: Union[str, None] = 'b2f4a7c83d91'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'content',
+        sa.Column('sync_task_id', sa.String(255), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('content', 'sync_task_id')

--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -1,11 +1,16 @@
 """Search API endpoints."""
 
+from celery.result import AsyncResult
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.database import get_db
+from app.models.content import Content
+from app.models.season import Season
 from app.services.content_repository import ContentRepository
+from app.workers.celery_app import celery_app
 
 router = APIRouter()
 
@@ -201,3 +206,72 @@ async def get_season_episodes(
     repo = ContentRepository(db)
     episodes = await repo.get_season_episodes(series_id, season_number)
     return {"season_number": season_number, "episodes": episodes, "count": len(episodes)}
+
+
+class SyncStatusResponse(BaseModel):
+    """Sync status response model."""
+
+    status: str  # 'idle' or 'syncing'
+    sync_type: str | None  # 'new' or 'update' or null
+    has_seasons: bool
+
+
+@router.get("/series/{series_id}/sync-status", response_model=SyncStatusResponse)
+async def get_series_sync_status(series_id: int, db: AsyncSession = Depends(get_db)):
+    """
+    Get the sync status for a TV series.
+
+    Returns whether the series is currently being synced, and whether this is
+    a new sync (first-time fetch) or an update (refreshing existing data).
+
+    Args:
+        series_id: TVDB series ID
+
+    Returns:
+        Sync status information
+    """
+    # Find content by tvdb_id
+    stmt = select(Content).where(
+        Content.tvdb_id == series_id,
+        Content.content_type == "series"
+    )
+    result = await db.execute(stmt)
+    content = result.scalar_one_or_none()
+
+    if not content:
+        # Content doesn't exist yet - check if there's a pending task
+        # For now, return idle - the task will create the content
+        return SyncStatusResponse(
+            status="idle",
+            sync_type=None,
+            has_seasons=False
+        )
+
+    # Check if seasons exist
+    stmt = select(Season).where(Season.content_id == content.id).limit(1)
+    result = await db.execute(stmt)
+    has_seasons = result.scalar_one_or_none() is not None
+
+    # Determine sync_type based on whether seasons exist
+    sync_type = "update" if has_seasons else "new"
+
+    # Check if sync_task_id exists and task is still running
+    if content.sync_task_id:
+        try:
+            task_result = AsyncResult(content.sync_task_id, app=celery_app)
+            # Check if task is still pending or started (not finished)
+            if task_result.state in ("PENDING", "STARTED", "RETRY"):
+                return SyncStatusResponse(
+                    status="syncing",
+                    sync_type=sync_type,
+                    has_seasons=has_seasons
+                )
+        except Exception:
+            # If we can't check the task, assume it's done
+            pass
+
+    return SyncStatusResponse(
+        status="idle",
+        sync_type=None,
+        has_seasons=has_seasons
+    )

--- a/backend/app/models/content.py
+++ b/backend/app/models/content.py
@@ -58,6 +58,7 @@ class Content(Base):
     # TVDB sync tracking
     tvdb_last_updated: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     last_synced_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), index=True)
+    sync_task_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/tasks/content.py
+++ b/backend/app/tasks/content.py
@@ -38,18 +38,31 @@ def save_series_full(self, tvdb_id: int, api_data: dict[str, Any] | None = None)
     time.sleep(jitter)
 
     start_time = datetime.utcnow()
+    task_id = self.request.id
 
     with SyncSessionLocal() as db:
         try:
+            # Set sync_task_id on content if it exists
+            stmt = select(Content).where(Content.tvdb_id == tvdb_id, Content.content_type == "series")
+            result = db.execute(stmt)
+            existing_content = result.scalar_one_or_none()
+            if existing_content:
+                existing_content.sync_task_id = task_id
+                db.commit()
+
             # Fetch from API if not provided
             if not api_data:
                 api_data = tvdb_service.get_series_details(tvdb_id)
 
             if not api_data:
+                # Clear sync_task_id on failure
+                if existing_content:
+                    existing_content.sync_task_id = None
+                    db.commit()
                 _log_sync_failure(db, "content", tvdb_id, "Series not found in TVDB API")
                 return {"status": "failed", "error": "Series not found"}
 
-            # Check if content already exists
+            # Check if content already exists (re-query in case it was created)
             stmt = select(Content).where(Content.tvdb_id == tvdb_id, Content.content_type == "series")
             result = db.execute(stmt)
             content = result.scalar_one_or_none()
@@ -61,6 +74,8 @@ def save_series_full(self, tvdb_id: int, api_data: dict[str, Any] | None = None)
                 # Create new
                 content = _create_series(db, tvdb_id, api_data)
 
+            # Set sync_task_id on content (for new content or ensure it's set)
+            content.sync_task_id = task_id
             db.commit()
             db.refresh(content)
 
@@ -72,6 +87,8 @@ def save_series_full(self, tvdb_id: int, api_data: dict[str, Any] | None = None)
             # Save seasons and episodes for series
             _save_seasons_and_episodes(db, content, tvdb_id, api_data)
 
+            # Clear sync_task_id on success
+            content.sync_task_id = None
             db.commit()
 
             # Log success
@@ -83,6 +100,16 @@ def save_series_full(self, tvdb_id: int, api_data: dict[str, Any] | None = None)
 
         except Exception as e:
             db.rollback()
+            # Clear sync_task_id on failure
+            try:
+                stmt = select(Content).where(Content.tvdb_id == tvdb_id, Content.content_type == "series")
+                result = db.execute(stmt)
+                content = result.scalar_one_or_none()
+                if content:
+                    content.sync_task_id = None
+                    db.commit()
+            except Exception:
+                pass  # Don't fail if cleanup fails
             _log_sync_failure(db, "content", tvdb_id, str(e))
             db.commit()
             raise

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -140,6 +140,11 @@ export const api = {
 			return request(`/series/${id}/season/${seasonNumber}/episodes`, {
 				requiresAuth: true
 			});
+		},
+		getSyncStatus: async (id: number) => {
+			return request(`/series/${id}/sync-status`, {
+				requiresAuth: true
+			});
 		}
 	},
 	checkin: {

--- a/frontend/src/routes/show/[id]/+page.svelte
+++ b/frontend/src/routes/show/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { api } from '$lib/api';
 	import { goto } from '$app/navigation';
 	import CheckInModal from '$lib/components/CheckInModal.svelte';
@@ -15,6 +15,11 @@
 	let loadingSeasons = false;
 	let expandedSeasons = new Set<number>();
 	let checkedInEpisodes = new Set<number>();
+
+	// Sync status state
+	let syncStatus: 'idle' | 'syncing' = 'idle';
+	let syncType: 'new' | 'update' | null = null;
+	let syncPollInterval: ReturnType<typeof setInterval> | null = null;
 
 	// Check-in modal state
 	let showCheckInModal = false;
@@ -33,6 +38,46 @@
 	onMount(async () => {
 		await loadDetails();
 	});
+
+	onDestroy(() => {
+		if (syncPollInterval) {
+			clearInterval(syncPollInterval);
+			syncPollInterval = null;
+		}
+	});
+
+	async function checkSyncStatus() {
+		try {
+			const response = await api.search.getSyncStatus(parseInt(id));
+			const wasSyncing = syncStatus === 'syncing';
+			syncStatus = response.status;
+			syncType = response.sync_type;
+
+			if (response.status === 'syncing') {
+				// Start polling if not already
+				if (!syncPollInterval) {
+					syncPollInterval = setInterval(checkSyncStatus, 3000);
+				}
+			} else {
+				// Stop polling
+				if (syncPollInterval) {
+					clearInterval(syncPollInterval);
+					syncPollInterval = null;
+				}
+				// Reload seasons if we were syncing or have none
+				if (wasSyncing || seasons.length === 0) {
+					await loadSeasons();
+					// Switch to seasons tab if seasons are now available and no cast
+					if (seasons.length > 0 && (!data?.characters || data.characters.length === 0)) {
+						activeMainTab = 'seasons';
+					}
+				}
+			}
+		} catch (e) {
+			console.error('Failed to check sync status:', e);
+			syncStatus = 'idle';
+		}
+	}
 
 	async function loadDetails() {
 		loading = true;
@@ -71,9 +116,9 @@
 			loading = false;
 		}
 
-		// If it's a series, load seasons and check-ins
+		// If it's a series, load seasons, check-ins, and sync status
 		if (isSeries && data) {
-			await Promise.all([loadSeasons(), loadCheckins()]);
+			await Promise.all([loadSeasons(), loadCheckins(), checkSyncStatus()]);
 		}
 	}
 
@@ -317,7 +362,7 @@
 		</div>
 
 		<!-- Cast & Crew and Seasons -->
-		{#if (data.characters && data.characters.length > 0) || (isSeries && seasons.length > 0)}
+		{#if (data.characters && data.characters.length > 0) || (isSeries && seasons.length > 0) || (isSeries && syncStatus === 'syncing')}
 			{@const sortedCharacters = data.characters ? [...data.characters].sort((a, b) => (a.sort || 999) - (b.sort || 999)) : []}
 			{@const actors = sortedCharacters.filter(c => c.peopleType === 'Actor')}
 			{@const directors = sortedCharacters.filter(c => c.peopleType === 'Director')}
@@ -338,14 +383,24 @@
 								Cast & Crew
 							</button>
 						{/if}
-						{#if isSeries && seasons.length > 0}
-							<button
-								on:click={() => activeMainTab = 'seasons'}
-								class="whitespace-nowrap py-4 px-1 border-b-2 font-medium text-base transition-colors
-									{activeMainTab === 'seasons' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}"
-							>
-								Seasons ({seasons.length})
-							</button>
+						{#if isSeries}
+							{#if syncStatus === 'syncing'}
+								<span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent font-medium text-base text-gray-400 cursor-not-allowed flex items-center gap-2">
+									<svg class="animate-spin h-4 w-4" viewBox="0 0 24 24">
+										<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" fill="none"></circle>
+										<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+									</svg>
+									{syncType === 'new' ? 'Retrieving episode info' : 'Updating episode info'}
+								</span>
+							{:else if seasons.length > 0}
+								<button
+									on:click={() => activeMainTab = 'seasons'}
+									class="whitespace-nowrap py-4 px-1 border-b-2 font-medium text-base transition-colors
+										{activeMainTab === 'seasons' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}"
+								>
+									Seasons ({seasons.length})
+								</button>
+							{/if}
 						{/if}
 					</nav>
 				</div>


### PR DESCRIPTION
## Summary

Add a dynamic tab indicator that shows the sync status when season/episode data is being fetched or updated for a TV show. This improves user experience by providing feedback during background data synchronization.

## Changes

### Backend
- Add `sync_task_id` column to Content model to track running Celery tasks
- Add database migration for the new column
- Update `save_series_full` task to set/clear `sync_task_id` during sync lifecycle
- Add `GET /series/{id}/sync-status` endpoint that returns:
  - `status`: 'idle' or 'syncing'
  - `sync_type`: 'new' (first fetch) or 'update' (refresh)
  - `has_seasons`: whether seasons exist in the database

### Frontend
- Add `getSyncStatus()` API method
- Add sync status polling mechanism (every 3 seconds while syncing)
- Update show page tabs to display:
  - "Retrieving episode info" (with spinner) for new shows
  - "Updating episode info" (with spinner) for refreshing data
  - "Seasons (N)" button when sync is complete

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Chore (dependencies, CI, etc.)

## Testing

1. **New show**: Search for a show not in the database, view it, confirm "Retrieving episode info" appears then transitions to "Seasons"
2. **Stale show**: View a show with `last_synced_at > 7 days`, confirm "Updating episode info" appears
3. **Cached show**: View a recently synced show, confirm "Seasons" appears immediately
4. **Page refresh during sync**: Refresh page mid-sync, confirm polling resumes correctly

All existing tests pass.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's style guidelines

---
🤖 Generated with [Claude Code](https://claude.ai/code)