### PR TITLE
Add watchlist feature for tracking shows and people

### DIFF
--- a/backend/alembic/versions/c8d2f3a91b47_add_watchlist_table.py
+++ b/backend/alembic/versions/c8d2f3a91b47_add_watchlist_table.py
@@ -1,0 +1,65 @@
+"""Add watchlist table
+
+Revision ID: c8d2f3a91b47
+Revises: b2f4a7c83d91
+Create Date: 2026-03-06 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c8d2f3a91b47'
+down_revision: Union[str, None] = 'b2f4a7c83d91'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create watchlist table with inline enum creation
+    op.create_table(
+        'watchlist',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('item_type', sa.Enum('content', 'person', name='watchlist_item_type_enum', create_constraint=True), nullable=False),
+        sa.Column('content_id', sa.Integer(), nullable=True),
+        sa.Column('person_id', sa.Integer(), nullable=True),
+        sa.Column('person_role_filter', sa.Enum('any', 'actor', 'director', name='person_role_filter_enum', create_constraint=True), nullable=True),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['content_id'], ['content.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['person_id'], ['person.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('user_id', 'content_id', name='uq_watchlist_user_content'),
+        sa.UniqueConstraint('user_id', 'person_id', name='uq_watchlist_user_person'),
+    )
+
+    # Create indexes
+    op.create_index(op.f('ix_watchlist_id'), 'watchlist', ['id'], unique=False)
+    op.create_index(op.f('ix_watchlist_user_id'), 'watchlist', ['user_id'], unique=False)
+    op.create_index(op.f('ix_watchlist_item_type'), 'watchlist', ['item_type'], unique=False)
+    op.create_index(op.f('ix_watchlist_content_id'), 'watchlist', ['content_id'], unique=False)
+    op.create_index(op.f('ix_watchlist_person_id'), 'watchlist', ['person_id'], unique=False)
+    op.create_index('idx_watchlist_user_item_type', 'watchlist', ['user_id', 'item_type'], unique=False)
+
+
+def downgrade() -> None:
+    # Drop indexes
+    op.drop_index('idx_watchlist_user_item_type', table_name='watchlist')
+    op.drop_index(op.f('ix_watchlist_person_id'), table_name='watchlist')
+    op.drop_index(op.f('ix_watchlist_content_id'), table_name='watchlist')
+    op.drop_index(op.f('ix_watchlist_item_type'), table_name='watchlist')
+    op.drop_index(op.f('ix_watchlist_user_id'), table_name='watchlist')
+    op.drop_index(op.f('ix_watchlist_id'), table_name='watchlist')
+
+    # Drop table
+    op.drop_table('watchlist')
+
+    # Drop enum types
+    sa.Enum(name='person_role_filter_enum').drop(op.get_bind(), checkfirst=True)
+    sa.Enum(name='watchlist_item_type_enum').drop(op.get_bind(), checkfirst=True)

--- a/backend/app/api/watchlist.py
+++ b/backend/app/api/watchlist.py
@@ -1,0 +1,567 @@
+"""Watchlist API endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.deps import get_current_user
+from app.db.database import get_db
+from app.models.content import Content
+from app.models.person import Person
+from app.models.user import User
+from app.models.watchlist import WatchlistItem, WatchlistItemType
+from app.schemas.watchlist import (
+    WatchlistCheckResponse,
+    WatchlistContentCreate,
+    WatchlistContentUpdate,
+    WatchlistItemResponse,
+    WatchlistPersonCreate,
+    WatchlistPersonUpdate,
+)
+
+router = APIRouter(prefix="/watchlist", tags=["watchlist"])
+
+
+@router.get("", response_model=list[WatchlistItemResponse])
+async def list_watchlist(
+    item_type: WatchlistItemType | None = None,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    List all watchlist items for the current user.
+
+    Args:
+        item_type: Optional filter by item type (content or person)
+        current_user: Current authenticated user
+        db: Database session
+
+    Returns:
+        List of watchlist items
+    """
+    query = (
+        select(WatchlistItem)
+        .where(WatchlistItem.user_id == current_user.id)
+        .options(selectinload(WatchlistItem.content), selectinload(WatchlistItem.person))
+        .order_by(WatchlistItem.created_at.desc())
+    )
+
+    if item_type:
+        query = query.where(WatchlistItem.item_type == item_type)
+
+    result = await db.execute(query)
+    items = result.scalars().all()
+
+    return [WatchlistItemResponse.model_validate(item) for item in items]
+
+
+@router.post("/content", response_model=WatchlistItemResponse, status_code=status.HTTP_201_CREATED)
+async def add_content_to_watchlist(
+    watchlist_data: WatchlistContentCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Add content (show/movie) to watchlist.
+
+    Args:
+        watchlist_data: Content watchlist data
+        current_user: Current authenticated user
+        db: Database session
+
+    Returns:
+        Created watchlist item
+
+    Raises:
+        HTTPException: If content not found or already in watchlist
+    """
+    # Find content by TVDB ID
+    result = await db.execute(select(Content).where(Content.tvdb_id == watchlist_data.tvdb_id))
+    content = result.scalar_one_or_none()
+
+    # If not in DB, fetch from TVDB and create basic record
+    if not content:
+        from datetime import datetime
+        from app.services.tvdb import tvdb_service
+        from app.tasks.content import save_movie_full, save_series_full
+
+        # Try movie first, then series
+        api_data = tvdb_service.get_movie_details(watchlist_data.tvdb_id)
+        is_movie = True
+        if not api_data:
+            api_data = tvdb_service.get_series_details(watchlist_data.tvdb_id)
+            is_movie = False
+
+        if not api_data:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Content with TVDB ID {watchlist_data.tvdb_id} not found on TVDB",
+            )
+
+        # Convert year to int if needed
+        year = api_data.get("year")
+        if year and isinstance(year, str):
+            try:
+                year = int(year)
+            except (ValueError, TypeError):
+                year = None
+
+        # Create basic content record
+        content = Content(
+            tvdb_id=watchlist_data.tvdb_id,
+            content_type="movie" if is_movie else "series",
+            name=api_data.get("name"),
+            overview=api_data.get("overview"),
+            year=year,
+            status=api_data.get("status", {}).get("name") if isinstance(api_data.get("status"), dict) else api_data.get("status"),
+            image_url=api_data.get("image"),
+            last_synced_at=datetime.utcnow(),
+        )
+        db.add(content)
+        await db.flush()
+
+        # Queue background task for full sync
+        if is_movie:
+            save_movie_full.delay(watchlist_data.tvdb_id, api_data)
+        else:
+            save_series_full.delay(watchlist_data.tvdb_id, api_data)
+
+    # Check if already in watchlist
+    existing = await db.execute(
+        select(WatchlistItem).where(
+            WatchlistItem.user_id == current_user.id,
+            WatchlistItem.content_id == content.id,
+        )
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Content already in watchlist",
+        )
+
+    # Create watchlist item
+    item = WatchlistItem(
+        user_id=current_user.id,
+        item_type=WatchlistItemType.CONTENT,
+        content_id=content.id,
+        notes=watchlist_data.notes,
+    )
+
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+
+    # Load relationships
+    result = await db.execute(
+        select(WatchlistItem)
+        .where(WatchlistItem.id == item.id)
+        .options(selectinload(WatchlistItem.content), selectinload(WatchlistItem.person))
+    )
+    item = result.scalar_one()
+
+    return WatchlistItemResponse.model_validate(item)
+
+
+@router.post("/person", response_model=WatchlistItemResponse, status_code=status.HTTP_201_CREATED)
+async def add_person_to_watchlist(
+    watchlist_data: WatchlistPersonCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Add person (actor/director) to watchlist.
+
+    Args:
+        watchlist_data: Person watchlist data
+        current_user: Current authenticated user
+        db: Database session
+
+    Returns:
+        Created watchlist item
+
+    Raises:
+        HTTPException: If person not found or already in watchlist
+    """
+    # Find person by TVDB ID
+    result = await db.execute(select(Person).where(Person.tvdb_id == watchlist_data.person_id))
+    person = result.scalar_one_or_none()
+
+    # If not in DB, fetch from TVDB and create basic record
+    if not person:
+        from app.services.tvdb import tvdb_service
+        from app.tasks.person import save_person_full
+
+        api_data = tvdb_service.get_person_details(watchlist_data.person_id)
+        if not api_data:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Person with TVDB ID {watchlist_data.person_id} not found on TVDB",
+            )
+
+        # Create basic person record
+        person = Person(
+            tvdb_id=watchlist_data.person_id,
+            full_name=api_data.get("name", "Unknown"),
+            first_name=api_data.get("firstName"),
+            last_name=api_data.get("lastName"),
+            image_url=api_data.get("image"),
+            biography=api_data.get("biography") if isinstance(api_data.get("biography"), str) else None,
+        )
+        db.add(person)
+        await db.flush()
+
+        # Queue background task for full sync
+        save_person_full.delay(watchlist_data.person_id, api_data)
+
+    # Check if already in watchlist
+    existing = await db.execute(
+        select(WatchlistItem).where(
+            WatchlistItem.user_id == current_user.id,
+            WatchlistItem.person_id == person.id,
+        )
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Person already in watchlist",
+        )
+
+    # Create watchlist item
+    item = WatchlistItem(
+        user_id=current_user.id,
+        item_type=WatchlistItemType.PERSON,
+        person_id=person.id,
+        person_role_filter=watchlist_data.person_role_filter,
+        notes=watchlist_data.notes,
+    )
+
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+
+    # Load relationships
+    result = await db.execute(
+        select(WatchlistItem)
+        .where(WatchlistItem.id == item.id)
+        .options(selectinload(WatchlistItem.content), selectinload(WatchlistItem.person))
+    )
+    item = result.scalar_one()
+
+    return WatchlistItemResponse.model_validate(item)
+
+
+@router.patch("/content/{tvdb_id}", response_model=WatchlistItemResponse)
+async def update_content_watchlist(
+    tvdb_id: int,
+    update_data: WatchlistContentUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Update watchlist content entry.
+
+    Args:
+        tvdb_id: TVDB ID of the content
+        update_data: Update data
+        current_user: Current authenticated user
+        db: Database session
+
+    Returns:
+        Updated watchlist item
+
+    Raises:
+        HTTPException: If content not found in watchlist
+    """
+    # Find content by TVDB ID
+    content_result = await db.execute(select(Content).where(Content.tvdb_id == tvdb_id))
+    content = content_result.scalar_one_or_none()
+
+    if not content:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Content with TVDB ID {tvdb_id} not found",
+        )
+
+    # Find watchlist item
+    result = await db.execute(
+        select(WatchlistItem).where(
+            WatchlistItem.user_id == current_user.id,
+            WatchlistItem.content_id == content.id,
+        )
+    )
+    item = result.scalar_one_or_none()
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Content not in watchlist",
+        )
+
+    # Update fields
+    update_dict = update_data.model_dump(exclude_unset=True)
+    for field, value in update_dict.items():
+        setattr(item, field, value)
+
+    await db.commit()
+    await db.refresh(item)
+
+    # Load relationships
+    result = await db.execute(
+        select(WatchlistItem)
+        .where(WatchlistItem.id == item.id)
+        .options(selectinload(WatchlistItem.content), selectinload(WatchlistItem.person))
+    )
+    item = result.scalar_one()
+
+    return WatchlistItemResponse.model_validate(item)
+
+
+@router.patch("/person/{person_id}", response_model=WatchlistItemResponse)
+async def update_person_watchlist(
+    person_id: int,
+    update_data: WatchlistPersonUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Update watchlist person entry.
+
+    Args:
+        person_id: TVDB ID of the person
+        update_data: Update data
+        current_user: Current authenticated user
+        db: Database session
+
+    Returns:
+        Updated watchlist item
+
+    Raises:
+        HTTPException: If person not found in watchlist
+    """
+    # Find person by TVDB ID
+    person_result = await db.execute(select(Person).where(Person.tvdb_id == person_id))
+    person = person_result.scalar_one_or_none()
+
+    if not person:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Person with TVDB ID {person_id} not found",
+        )
+
+    # Find watchlist item
+    result = await db.execute(
+        select(WatchlistItem).where(
+            WatchlistItem.user_id == current_user.id,
+            WatchlistItem.person_id == person.id,
+        )
+    )
+    item = result.scalar_one_or_none()
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Person not in watchlist",
+        )
+
+    # Update fields
+    update_dict = update_data.model_dump(exclude_unset=True)
+    for field, value in update_dict.items():
+        setattr(item, field, value)
+
+    await db.commit()
+    await db.refresh(item)
+
+    # Load relationships
+    result = await db.execute(
+        select(WatchlistItem)
+        .where(WatchlistItem.id == item.id)
+        .options(selectinload(WatchlistItem.content), selectinload(WatchlistItem.person))
+    )
+    item = result.scalar_one()
+
+    return WatchlistItemResponse.model_validate(item)
+
+
+@router.delete("/content/{tvdb_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_content_from_watchlist(
+    tvdb_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Remove content from watchlist.
+
+    Args:
+        tvdb_id: TVDB ID of the content
+        current_user: Current authenticated user
+        db: Database session
+
+    Raises:
+        HTTPException: If content not found in watchlist
+    """
+    # Find content by TVDB ID
+    content_result = await db.execute(select(Content).where(Content.tvdb_id == tvdb_id))
+    content = content_result.scalar_one_or_none()
+
+    if not content:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Content with TVDB ID {tvdb_id} not found",
+        )
+
+    # Find watchlist item
+    result = await db.execute(
+        select(WatchlistItem).where(
+            WatchlistItem.user_id == current_user.id,
+            WatchlistItem.content_id == content.id,
+        )
+    )
+    item = result.scalar_one_or_none()
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Content not in watchlist",
+        )
+
+    await db.delete(item)
+    await db.commit()
+
+    return None
+
+
+@router.delete("/person/{person_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_person_from_watchlist(
+    person_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Remove person from watchlist.
+
+    Args:
+        person_id: TVDB ID of the person
+        current_user: Current authenticated user
+        db: Database session
+
+    Raises:
+        HTTPException: If person not found in watchlist
+    """
+    # Find person by TVDB ID
+    person_result = await db.execute(select(Person).where(Person.tvdb_id == person_id))
+    person = person_result.scalar_one_or_none()
+
+    if not person:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Person with TVDB ID {person_id} not found",
+        )
+
+    # Find watchlist item
+    result = await db.execute(
+        select(WatchlistItem).where(
+            WatchlistItem.user_id == current_user.id,
+            WatchlistItem.person_id == person.id,
+        )
+    )
+    item = result.scalar_one_or_none()
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Person not in watchlist",
+        )
+
+    await db.delete(item)
+    await db.commit()
+
+    return None
+
+
+@router.get("/check/content/{tvdb_id}", response_model=WatchlistCheckResponse)
+async def check_content_in_watchlist(
+    tvdb_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Check if content is in watchlist.
+
+    Args:
+        tvdb_id: TVDB ID of the content
+        current_user: Current authenticated user
+        db: Database session
+
+    Returns:
+        Whether content is in watchlist and the item if it exists
+    """
+    # Find content by TVDB ID
+    content_result = await db.execute(select(Content).where(Content.tvdb_id == tvdb_id))
+    content = content_result.scalar_one_or_none()
+
+    if not content:
+        return WatchlistCheckResponse(in_watchlist=False, item=None)
+
+    # Find watchlist item
+    result = await db.execute(
+        select(WatchlistItem)
+        .where(
+            WatchlistItem.user_id == current_user.id,
+            WatchlistItem.content_id == content.id,
+        )
+        .options(selectinload(WatchlistItem.content), selectinload(WatchlistItem.person))
+    )
+    item = result.scalar_one_or_none()
+
+    if item:
+        return WatchlistCheckResponse(
+            in_watchlist=True,
+            item=WatchlistItemResponse.model_validate(item),
+        )
+
+    return WatchlistCheckResponse(in_watchlist=False, item=None)
+
+
+@router.get("/check/person/{person_id}", response_model=WatchlistCheckResponse)
+async def check_person_in_watchlist(
+    person_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Check if person is in watchlist.
+
+    Args:
+        person_id: TVDB ID of the person
+        current_user: Current authenticated user
+        db: Database session
+
+    Returns:
+        Whether person is in watchlist and the item if it exists
+    """
+    # Find person by TVDB ID
+    person_result = await db.execute(select(Person).where(Person.tvdb_id == person_id))
+    person = person_result.scalar_one_or_none()
+
+    if not person:
+        return WatchlistCheckResponse(in_watchlist=False, item=None)
+
+    # Find watchlist item
+    result = await db.execute(
+        select(WatchlistItem)
+        .where(
+            WatchlistItem.user_id == current_user.id,
+            WatchlistItem.person_id == person.id,
+        )
+        .options(selectinload(WatchlistItem.content), selectinload(WatchlistItem.person))
+    )
+    item = result.scalar_one_or_none()
+
+    if item:
+        return WatchlistCheckResponse(
+            in_watchlist=True,
+            item=WatchlistItemResponse.model_validate(item),
+        )
+
+    return WatchlistCheckResponse(in_watchlist=False, item=None)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 
-from app.api import auth, checkin, search, swanson
+from app.api import auth, checkin, search, swanson, watchlist
 from app.core.config import settings
 from app.db.redis import close_redis, get_redis
 
@@ -55,6 +55,7 @@ app.include_router(auth.router)
 app.include_router(search.router, tags=["search"])
 app.include_router(checkin.router)
 app.include_router(swanson.router)
+app.include_router(watchlist.router)
 
 
 @app.get("/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from app.models.sync_log import SyncLog
 from app.models.season import Season
 from app.models.episode import Episode
 from app.models.checkin import Checkin
+from app.models.watchlist import WatchlistItem, WatchlistItemType, PersonRoleFilter
 
 __all__ = [
     "User",
@@ -27,4 +28,7 @@ __all__ = [
     "Season",
     "Episode",
     "Checkin",
+    "WatchlistItem",
+    "WatchlistItemType",
+    "PersonRoleFilter",
 ]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -10,6 +10,7 @@ from app.db.database import Base
 
 if TYPE_CHECKING:
     from app.models.checkin import Checkin
+    from app.models.watchlist import WatchlistItem
 
 
 class User(Base):
@@ -36,6 +37,12 @@ class User(Base):
         back_populates="user",
         cascade="all, delete-orphan",
         order_by="Checkin.watched_at.desc()"
+    )
+    watchlist_items: Mapped[list["WatchlistItem"]] = relationship(
+        "WatchlistItem",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        order_by="WatchlistItem.created_at.desc()"
     )
 
     def __repr__(self) -> str:

--- a/backend/app/models/watchlist.py
+++ b/backend/app/models/watchlist.py
@@ -1,0 +1,112 @@
+"""Watchlist model."""
+
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, Text, UniqueConstraint
+from sqlalchemy import Enum as SQLEnum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.database import Base
+
+if TYPE_CHECKING:
+    from app.models.content import Content
+    from app.models.person import Person
+    from app.models.user import User
+
+
+class WatchlistItemType(str, Enum):
+    """Type of watchlist item."""
+
+    CONTENT = "content"
+    PERSON = "person"
+
+
+class PersonRoleFilter(str, Enum):
+    """Filter for person roles to watch for."""
+
+    ANY = "any"
+    ACTOR = "actor"
+    DIRECTOR = "director"
+
+
+class WatchlistItem(Base):
+    """Watchlist item model for tracking shows, movies, and people to follow."""
+
+    __tablename__ = "watchlist"
+
+    # Primary key
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+
+    # User who owns the item
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    # Item type (content or person)
+    item_type: Mapped[WatchlistItemType] = mapped_column(
+        SQLEnum(
+            WatchlistItemType,
+            name="watchlist_item_type_enum",
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=False,
+        index=True,
+    )
+
+    # Content reference (for shows/movies)
+    content_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("content.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+
+    # Person reference (for actors/directors)
+    person_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("person.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+
+    # Role filter for persons (what role to watch for)
+    person_role_filter: Mapped[PersonRoleFilter | None] = mapped_column(
+        SQLEnum(
+            PersonRoleFilter,
+            name="person_role_filter_enum",
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=True,
+        default=PersonRoleFilter.ANY,
+    )
+
+    # Optional notes
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+    # Relationships
+    user: Mapped["User"] = relationship("User", back_populates="watchlist_items")
+    content: Mapped["Content | None"] = relationship("Content", lazy="selectin")
+    person: Mapped["Person | None"] = relationship("Person", lazy="selectin")
+
+    # Indexes and constraints
+    __table_args__ = (
+        # Unique constraint: user can only have one watchlist entry per content
+        UniqueConstraint("user_id", "content_id", name="uq_watchlist_user_content"),
+        # Unique constraint: user can only have one watchlist entry per person
+        UniqueConstraint("user_id", "person_id", name="uq_watchlist_user_person"),
+        # Index for efficient lookups
+        Index("idx_watchlist_user_item_type", "user_id", "item_type"),
+    )
+
+    def __repr__(self) -> str:
+        """String representation of WatchlistItem."""
+        if self.item_type == WatchlistItemType.CONTENT:
+            return f"<WatchlistItem(id={self.id}, user_id={self.user_id}, content_id={self.content_id})>"
+        return f"<WatchlistItem(id={self.id}, user_id={self.user_id}, person_id={self.person_id})>"

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -15,6 +15,16 @@ from app.schemas.checkin import (
     ContentSummary,
     EpisodeSummary,
 )
+from app.schemas.watchlist import (
+    WatchlistCheckResponse,
+    WatchlistContentCreate,
+    WatchlistContentUpdate,
+    WatchlistItemResponse,
+    WatchlistItemType,
+    WatchlistPersonCreate,
+    WatchlistPersonUpdate,
+    PersonRoleFilter,
+)
 
 __all__ = [
     "LoginRequest",
@@ -28,4 +38,12 @@ __all__ = [
     "CheckinUpdate",
     "ContentSummary",
     "EpisodeSummary",
+    "WatchlistCheckResponse",
+    "WatchlistContentCreate",
+    "WatchlistContentUpdate",
+    "WatchlistItemResponse",
+    "WatchlistItemType",
+    "WatchlistPersonCreate",
+    "WatchlistPersonUpdate",
+    "PersonRoleFilter",
 ]

--- a/backend/app/schemas/watchlist.py
+++ b/backend/app/schemas/watchlist.py
@@ -1,0 +1,113 @@
+"""Watchlist schemas."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class WatchlistItemType(str, Enum):
+    """Type of watchlist item."""
+
+    CONTENT = "content"
+    PERSON = "person"
+
+
+class PersonRoleFilter(str, Enum):
+    """Filter for person roles to watch for."""
+
+    ANY = "any"
+    ACTOR = "actor"
+    DIRECTOR = "director"
+
+
+# --- Content schemas ---
+
+
+class WatchlistContentCreate(BaseModel):
+    """Schema for adding content to watchlist."""
+
+    tvdb_id: int = Field(..., description="TVDB ID of the content (movie or series)")
+    notes: Optional[str] = Field(None, description="Optional notes")
+
+
+class WatchlistContentUpdate(BaseModel):
+    """Schema for updating watchlist content entry."""
+
+    notes: Optional[str] = Field(None, description="Optional notes")
+
+
+# --- Person schemas ---
+
+
+class WatchlistPersonCreate(BaseModel):
+    """Schema for adding a person to watchlist."""
+
+    person_id: int = Field(..., description="TVDB ID of the person")
+    person_role_filter: PersonRoleFilter = Field(
+        PersonRoleFilter.ANY, description="What role to watch for"
+    )
+    notes: Optional[str] = Field(None, description="Optional notes")
+
+
+class WatchlistPersonUpdate(BaseModel):
+    """Schema for updating watchlist person entry."""
+
+    person_role_filter: Optional[PersonRoleFilter] = None
+    notes: Optional[str] = None
+
+
+# --- Summary schemas for embedded data ---
+
+
+class ContentSummary(BaseModel):
+    """Summary of content for watchlist response."""
+
+    id: int
+    tvdb_id: int
+    name: str
+    content_type: str
+    year: Optional[int] = None
+    poster_url: Optional[str] = None
+    image_url: Optional[str] = None
+    status: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+
+
+class PersonSummary(BaseModel):
+    """Summary of person for watchlist response."""
+
+    id: int
+    tvdb_id: int
+    full_name: str
+    image_url: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+
+
+# --- Response schemas ---
+
+
+class WatchlistItemResponse(BaseModel):
+    """Schema for watchlist item response."""
+
+    id: int
+    user_id: int
+    item_type: WatchlistItemType
+    content: Optional[ContentSummary] = None
+    person: Optional[PersonSummary] = None
+    person_role_filter: Optional[PersonRoleFilter] = None
+    notes: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class WatchlistCheckResponse(BaseModel):
+    """Schema for checking if item is in watchlist."""
+
+    in_watchlist: bool
+    item: Optional[WatchlistItemResponse] = None

--- a/backend/app/tasks/content.py
+++ b/backend/app/tasks/content.py
@@ -314,10 +314,14 @@ def _save_credits(db, content: Content, characters_data: list):
                 full_name=person_name,
                 first_name=first_name,
                 last_name=last_name,
+                image_url=char_data.get("personImgURL"),
                 last_synced_at=None  # Mark as needing sync
             )
             db.add(person)
             db.flush()
+        elif not person.image_url and char_data.get("personImgURL"):
+            # Update existing person's image if missing
+            person.image_url = char_data.get("personImgURL")
 
         # Create credit
         role_type_map = {

--- a/backend/app/tasks/person.py
+++ b/backend/app/tasks/person.py
@@ -114,3 +114,29 @@ def _log_sync_failure(db, tvdb_id: int, error_message: str):
         error_message=error_message
     )
     db.add(log)
+
+
+@celery_app.task
+def backfill_person_images():
+    """
+    Backfill missing person images by fetching from TVDB.
+
+    Queues save_person_full tasks for all persons without image_url.
+    Run with: celery -A app.workers.celery_app call app.tasks.person.backfill_person_images
+    """
+    with SyncSessionLocal() as db:
+        # Find all persons without images
+        stmt = select(Person).where(Person.image_url.is_(None))
+        result = db.execute(stmt)
+        persons = result.scalars().all()
+
+        queued = 0
+        for person in persons:
+            save_person_full.delay(person.tvdb_id)
+            queued += 1
+
+        return {
+            "status": "success",
+            "queued": queued,
+            "message": f"Queued {queued} persons for image sync."
+        }

--- a/backend/tests/api/__init__.py
+++ b/backend/tests/api/__init__.py
@@ -1,0 +1,1 @@
+"""API tests package."""

--- a/backend/tests/api/test_watchlist.py
+++ b/backend/tests/api/test_watchlist.py
@@ -1,0 +1,95 @@
+"""Tests for watchlist API endpoints."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models.watchlist import WatchlistItemType, PersonRoleFilter
+
+client = TestClient(app)
+
+
+class TestWatchlistEndpoints:
+    """Test watchlist API endpoints."""
+
+    def test_list_watchlist_requires_auth(self):
+        """Test that listing watchlist requires authentication."""
+        response = client.get("/watchlist")
+        # FastAPI returns 403 when no credentials provided with OAuth2
+        assert response.status_code in (401, 403)
+
+    def test_add_content_requires_auth(self):
+        """Test that adding content to watchlist requires authentication."""
+        response = client.post("/watchlist/content", json={"tvdb_id": 123})
+        assert response.status_code in (401, 403)
+
+    def test_add_person_requires_auth(self):
+        """Test that adding person to watchlist requires authentication."""
+        response = client.post(
+            "/watchlist/person",
+            json={"person_id": 456, "person_role_filter": "any"}
+        )
+        assert response.status_code in (401, 403)
+
+    def test_remove_content_requires_auth(self):
+        """Test that removing content from watchlist requires authentication."""
+        response = client.delete("/watchlist/content/123")
+        assert response.status_code in (401, 403)
+
+    def test_remove_person_requires_auth(self):
+        """Test that removing person from watchlist requires authentication."""
+        response = client.delete("/watchlist/person/456")
+        assert response.status_code in (401, 403)
+
+    def test_check_content_requires_auth(self):
+        """Test that checking content in watchlist requires authentication."""
+        response = client.get("/watchlist/check/content/123")
+        assert response.status_code in (401, 403)
+
+    def test_check_person_requires_auth(self):
+        """Test that checking person in watchlist requires authentication."""
+        response = client.get("/watchlist/check/person/456")
+        assert response.status_code in (401, 403)
+
+    def test_update_content_requires_auth(self):
+        """Test that updating content watchlist entry requires authentication."""
+        response = client.patch(
+            "/watchlist/content/123",
+            json={"notes": "Updated notes"}
+        )
+        assert response.status_code in (401, 403)
+
+    def test_update_person_requires_auth(self):
+        """Test that updating person watchlist entry requires authentication."""
+        response = client.patch(
+            "/watchlist/person/456",
+            json={"person_role_filter": "actor"}
+        )
+        assert response.status_code in (401, 403)
+
+
+class TestWatchlistItemType:
+    """Test WatchlistItemType enum."""
+
+    def test_content_value(self):
+        """Test content item type value."""
+        assert WatchlistItemType.CONTENT.value == "content"
+
+    def test_person_value(self):
+        """Test person item type value."""
+        assert WatchlistItemType.PERSON.value == "person"
+
+
+class TestPersonRoleFilter:
+    """Test PersonRoleFilter enum."""
+
+    def test_any_value(self):
+        """Test any role filter value."""
+        assert PersonRoleFilter.ANY.value == "any"
+
+    def test_actor_value(self):
+        """Test actor role filter value."""
+        assert PersonRoleFilter.ACTOR.value == "actor"
+
+    def test_director_value(self):
+        """Test director role filter value."""
+        assert PersonRoleFilter.DIRECTOR.value == "director"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -209,6 +209,80 @@ export const api = {
 			});
 		}
 	},
+	watchlist: {
+		list: async (itemType?: 'content' | 'person') => {
+			const params = new URLSearchParams();
+			if (itemType) {
+				params.append('item_type', itemType);
+			}
+			const queryString = params.toString();
+			return request(`/watchlist${queryString ? `?${queryString}` : ''}`, {
+				requiresAuth: true
+			});
+		},
+		addContent: async (tvdbId: number, notes?: string) => {
+			return request('/watchlist/content', {
+				method: 'POST',
+				body: JSON.stringify({ tvdb_id: tvdbId, notes }),
+				requiresAuth: true
+			});
+		},
+		addPerson: async (
+			personId: number,
+			personRoleFilter: 'any' | 'actor' | 'director' = 'any',
+			notes?: string
+		) => {
+			return request('/watchlist/person', {
+				method: 'POST',
+				body: JSON.stringify({
+					person_id: personId,
+					person_role_filter: personRoleFilter,
+					notes
+				}),
+				requiresAuth: true
+			});
+		},
+		updateContent: async (tvdbId: number, notes?: string) => {
+			return request(`/watchlist/content/${tvdbId}`, {
+				method: 'PATCH',
+				body: JSON.stringify({ notes }),
+				requiresAuth: true
+			});
+		},
+		updatePerson: async (
+			personId: number,
+			personRoleFilter?: 'any' | 'actor' | 'director',
+			notes?: string
+		) => {
+			return request(`/watchlist/person/${personId}`, {
+				method: 'PATCH',
+				body: JSON.stringify({ person_role_filter: personRoleFilter, notes }),
+				requiresAuth: true
+			});
+		},
+		removeContent: async (tvdbId: number) => {
+			return request(`/watchlist/content/${tvdbId}`, {
+				method: 'DELETE',
+				requiresAuth: true
+			});
+		},
+		removePerson: async (personId: number) => {
+			return request(`/watchlist/person/${personId}`, {
+				method: 'DELETE',
+				requiresAuth: true
+			});
+		},
+		checkContent: async (tvdbId: number) => {
+			return request(`/watchlist/check/content/${tvdbId}`, {
+				requiresAuth: true
+			});
+		},
+		checkPerson: async (personId: number) => {
+			return request(`/watchlist/check/person/${personId}`, {
+				requiresAuth: true
+			});
+		}
+	},
 	swanson: {
 		recommend: async (data: {
 			prompt: string;

--- a/frontend/src/lib/components/WatchlistButton.svelte
+++ b/frontend/src/lib/components/WatchlistButton.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+	import { createEventDispatcher, onMount } from 'svelte';
+	import { api } from '$lib/api';
+
+	export let type: 'content' | 'person';
+	export let id: number; // TVDB ID for content, person ID for person
+	export let personRoleFilter: 'any' | 'actor' | 'director' = 'any';
+	export let compact: boolean = false;
+
+	const dispatch = createEventDispatcher();
+
+	let inWatchlist = false;
+	let loading = false;
+	let checking = true;
+
+	onMount(async () => {
+		await checkWatchlistStatus();
+	});
+
+	async function checkWatchlistStatus() {
+		checking = true;
+		try {
+			const response =
+				type === 'content'
+					? await api.watchlist.checkContent(id)
+					: await api.watchlist.checkPerson(id);
+			inWatchlist = response.in_watchlist;
+		} catch (e) {
+			console.error('Failed to check watchlist status:', e);
+		} finally {
+			checking = false;
+		}
+	}
+
+	async function toggleWatchlist() {
+		if (loading) return;
+
+		loading = true;
+		try {
+			if (inWatchlist) {
+				// Remove from watchlist
+				if (type === 'content') {
+					await api.watchlist.removeContent(id);
+				} else {
+					await api.watchlist.removePerson(id);
+				}
+				inWatchlist = false;
+				dispatch('removed', { type, id });
+			} else {
+				// Add to watchlist
+				if (type === 'content') {
+					await api.watchlist.addContent(id);
+				} else {
+					await api.watchlist.addPerson(id, personRoleFilter);
+				}
+				inWatchlist = true;
+				dispatch('added', { type, id });
+			}
+		} catch (e: any) {
+			console.error('Failed to update watchlist:', e);
+			// Handle 409 conflict (already in watchlist)
+			if (e.message?.includes('already in watchlist')) {
+				inWatchlist = true;
+			}
+		} finally {
+			loading = false;
+		}
+	}
+</script>
+
+{#if checking}
+	<button
+		disabled
+		class="flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-200 bg-gray-50 text-gray-400 cursor-not-allowed
+			{compact ? 'px-3 py-1.5 text-sm' : ''}"
+	>
+		<svg class="animate-spin h-4 w-4" viewBox="0 0 24 24">
+			<circle
+				class="opacity-25"
+				cx="12"
+				cy="12"
+				r="10"
+				stroke="currentColor"
+				stroke-width="4"
+				fill="none"
+			></circle>
+			<path
+				class="opacity-75"
+				fill="currentColor"
+				d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+			></path>
+		</svg>
+		{#if !compact}
+			<span>Loading...</span>
+		{/if}
+	</button>
+{:else}
+	<button
+		on:click={toggleWatchlist}
+		disabled={loading}
+		class="flex items-center gap-2 rounded-lg border font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2
+			{compact ? 'px-3 py-1.5 text-sm' : 'px-4 py-2'}
+			{inWatchlist
+			? 'border-amber-300 bg-amber-50 text-amber-700 hover:bg-amber-100 focus:ring-amber-500'
+			: 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 focus:ring-indigo-500'}
+			{loading ? 'opacity-75 cursor-not-allowed' : ''}"
+		title={inWatchlist ? 'Remove from watchlist' : 'Add to watchlist'}
+	>
+		{#if loading}
+			<svg class="animate-spin h-4 w-4" viewBox="0 0 24 24">
+				<circle
+					class="opacity-25"
+					cx="12"
+					cy="12"
+					r="10"
+					stroke="currentColor"
+					stroke-width="4"
+					fill="none"
+				></circle>
+				<path
+					class="opacity-75"
+					fill="currentColor"
+					d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+				></path>
+			</svg>
+		{:else}
+			<!-- Bookmark icon -->
+			<svg
+				class="h-5 w-5 {compact ? 'h-4 w-4' : ''}"
+				fill={inWatchlist ? 'currentColor' : 'none'}
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				stroke-width="2"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+				/>
+			</svg>
+		{/if}
+		{#if !compact}
+			<span>{inWatchlist ? 'In Watchlist' : 'Add to Watchlist'}</span>
+		{/if}
+	</button>
+{/if}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
 		const segments = pathname.split('/').filter(s => s.length > 0);
 		if (segments.length !== 1) return false;
 
-		const knownRoutes = ['login', 'about', 'colophon', 'show', 'checkins', 'settings', 'swanson'];
+		const knownRoutes = ['login', 'about', 'colophon', 'show', 'checkins', 'settings', 'swanson', 'watchlist', 'person'];
 		return !knownRoutes.includes(segments[0]);
 	}
 
@@ -96,6 +96,14 @@
 								class:text-indigo-600={$page.url.pathname === '/checkins'}
 							>
 								Check-ins
+							</a>
+							<a
+								href="/watchlist"
+								class="border-transparent text-gray-500 hover:text-gray-900 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium hover:border-indigo-500 transition-colors"
+								class:border-indigo-500={$page.url.pathname === '/watchlist'}
+								class:text-indigo-600={$page.url.pathname === '/watchlist'}
+							>
+								Watchlist
 							</a>
 						</div>
 					</div>
@@ -196,6 +204,17 @@
 							class:text-gray-600={$page.url.pathname !== '/checkins'}
 						>
 							Check-ins
+						</a>
+						<a
+							href="/watchlist"
+							class="block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
+							class:border-indigo-500={$page.url.pathname === '/watchlist'}
+							class:bg-indigo-50={$page.url.pathname === '/watchlist'}
+							class:text-indigo-700={$page.url.pathname === '/watchlist'}
+							class:border-transparent={$page.url.pathname !== '/watchlist'}
+							class:text-gray-600={$page.url.pathname !== '/watchlist'}
+						>
+							Watchlist
 						</a>
 					</div>
 					<div class="pt-4 pb-3 border-t border-gray-200">

--- a/frontend/src/routes/person/[id]/+page.svelte
+++ b/frontend/src/routes/person/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api';
 	import { goto } from '$app/navigation';
+	import WatchlistButton from '$lib/components/WatchlistButton.svelte';
 
 	let loading = true;
 	let error = '';
@@ -163,7 +164,10 @@
 
 				<!-- Info -->
 				<div class="md:w-2/3 lg:w-3/4 p-6">
-					<h1 class="text-4xl font-bold text-gray-900 mb-4">{data.name}</h1>
+					<div class="flex flex-wrap items-start justify-between gap-4 mb-4">
+						<h1 class="text-4xl font-bold text-gray-900">{data.name}</h1>
+						<WatchlistButton type="person" id={parseInt(id)} personRoleFilter="any" />
+					</div>
 
 					<!-- Aliases -->
 					{#if data.aliases && getEnglishAliases(data.aliases).length > 0}

--- a/frontend/src/routes/show/[id]/+page.svelte
+++ b/frontend/src/routes/show/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import { api } from '$lib/api';
 	import { goto } from '$app/navigation';
 	import CheckInModal from '$lib/components/CheckInModal.svelte';
+	import WatchlistButton from '$lib/components/WatchlistButton.svelte';
 
 	let loading = true;
 	let error = '';
@@ -300,17 +301,18 @@
 						</div>
 					{/if}
 
-					<!-- Check-in Button -->
-					<div class="mt-6">
+					<!-- Action Buttons -->
+					<div class="mt-6 flex flex-col sm:flex-row gap-3">
 						<button
 							on:click={() => openCheckInModal()}
-							class="w-full px-4 py-3 bg-indigo-600 text-white font-semibold rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
+							class="flex-1 px-4 py-3 bg-indigo-600 text-white font-semibold rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
 						>
 							<svg class="w-5 h-5 inline-block mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
 							</svg>
 							Check In {isSeries ? 'Show' : 'Movie'}
 						</button>
+						<WatchlistButton type="content" id={parseInt(id)} />
 					</div>
 				</div>
 			</div>

--- a/frontend/src/routes/watchlist/+page.svelte
+++ b/frontend/src/routes/watchlist/+page.svelte
@@ -1,0 +1,291 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api';
+	import WatchlistButton from '$lib/components/WatchlistButton.svelte';
+
+	let loading = true;
+	let error = '';
+	let items: any[] = [];
+	let activeTab: 'content' | 'people' = 'content';
+
+	const PLACEHOLDER_POSTER =
+		'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="300" height="450"%3E%3Crect fill="%23e5e7eb" width="300" height="450"/%3E%3Ctext fill="%236b7280" font-family="Arial" font-size="20" x="50%25" y="50%25" text-anchor="middle" dominant-baseline="middle"%3ENo Poster%3C/text%3E%3C/svg%3E';
+	const PLACEHOLDER_PERSON =
+		'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="150" height="150"%3E%3Crect fill="%23e5e7eb" width="150" height="150"/%3E%3Ctext fill="%236b7280" font-family="Arial" font-size="16" x="50%25" y="50%25" text-anchor="middle" dominant-baseline="middle"%3ENo Image%3C/text%3E%3C/svg%3E';
+
+	onMount(async () => {
+		await loadWatchlist();
+	});
+
+	async function loadWatchlist() {
+		loading = true;
+		error = '';
+		try {
+			items = await api.watchlist.list();
+		} catch (e: any) {
+			error = e.message || 'Failed to load watchlist';
+		} finally {
+			loading = false;
+		}
+	}
+
+	// Filter items based on active tab
+	$: contentItems = items.filter((i) => i.item_type === 'content');
+	$: peopleItems = items.filter((i) => i.item_type === 'person');
+
+	// Get current items based on tab
+	$: currentItems = activeTab === 'content' ? contentItems : peopleItems;
+
+	function getPosterUrl(content: any): string {
+		return content?.image_url || content?.poster_url || PLACEHOLDER_POSTER;
+	}
+
+	function getPersonImage(person: any): string {
+		return person?.image_url || PLACEHOLDER_PERSON;
+	}
+
+	function handleRemoved(event: CustomEvent) {
+		// Remove item from local list
+		const { type, id } = event.detail;
+		items = items.filter((item) => {
+			if (type === 'content') {
+				return !(item.item_type === 'content' && item.content?.tvdb_id === id);
+			} else {
+				return !(item.item_type === 'person' && item.person?.tvdb_id === id);
+			}
+		});
+	}
+
+	function formatDate(dateStr: string): string {
+		return new Date(dateStr).toLocaleDateString('en-US', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric'
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>Watchlist - What Is On The TV</title>
+</svelte:head>
+
+<div class="max-w-7xl mx-auto px-4 py-8">
+	<div class="mb-8">
+		<h1 class="text-3xl font-bold text-gray-900">Watchlist</h1>
+		<p class="mt-2 text-gray-600">Keep track of shows, movies, and people you want to follow.</p>
+	</div>
+
+	{#if loading}
+		<div class="flex items-center justify-center min-h-[50vh]">
+			<div class="text-center">
+				<svg class="animate-spin h-12 w-12 text-indigo-600 mx-auto" viewBox="0 0 24 24">
+					<circle
+						class="opacity-25"
+						cx="12"
+						cy="12"
+						r="10"
+						stroke="currentColor"
+						stroke-width="4"
+						fill="none"
+					></circle>
+					<path
+						class="opacity-75"
+						fill="currentColor"
+						d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+					></path>
+				</svg>
+				<p class="mt-4 text-gray-600">Loading watchlist...</p>
+			</div>
+		</div>
+	{:else if error}
+		<div class="bg-red-50 border-l-4 border-red-500 p-4 rounded">
+			<p class="text-sm text-red-700">{error}</p>
+			<button on:click={loadWatchlist} class="mt-4 text-indigo-600 hover:text-indigo-800">
+				Try again
+			</button>
+		</div>
+	{:else}
+		<div class="bg-white rounded-lg shadow-lg">
+			<!-- Tabs -->
+			<div class="border-b border-gray-200">
+				<nav class="flex -mb-px px-6">
+					<button
+						on:click={() => (activeTab = 'content')}
+						class="whitespace-nowrap py-4 px-4 border-b-2 font-medium text-sm transition-colors
+							{activeTab === 'content'
+							? 'border-indigo-500 text-indigo-600'
+							: 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}"
+					>
+						Shows & Movies ({contentItems.length})
+					</button>
+					<button
+						on:click={() => (activeTab = 'people')}
+						class="whitespace-nowrap py-4 px-4 border-b-2 font-medium text-sm transition-colors
+							{activeTab === 'people'
+							? 'border-indigo-500 text-indigo-600'
+							: 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}"
+					>
+						People ({peopleItems.length})
+					</button>
+				</nav>
+			</div>
+
+			<!-- Content -->
+			<div class="p-6">
+				{#if currentItems.length === 0}
+					<div class="text-center py-12">
+						<svg
+							class="mx-auto h-12 w-12 text-gray-400"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+							/>
+						</svg>
+						<h3 class="mt-2 text-sm font-medium text-gray-900">No items yet</h3>
+						<p class="mt-1 text-sm text-gray-500">
+							{#if activeTab === 'content'}
+								Start adding shows and movies to your watchlist.
+							{:else}
+								Follow people to keep track of their new work.
+							{/if}
+						</p>
+						<div class="mt-6">
+							<a
+								href="/"
+								class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+							>
+								<svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+									/>
+								</svg>
+								Search for content
+							</a>
+						</div>
+					</div>
+				{:else if activeTab === 'content'}
+					<!-- Content Grid -->
+					<div
+						class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4"
+					>
+						{#each currentItems as item}
+							{@const content = item.content}
+							{#if content}
+								<div class="group relative">
+									<a
+										href="/show/{content.tvdb_id}{content.content_type === 'movie' ? '?type=movie' : ''}"
+										class="block bg-white rounded-lg shadow hover:shadow-lg transition-shadow"
+									>
+										<div class="aspect-[2/3] bg-gray-200 rounded-t-lg overflow-hidden">
+											<img
+												src={getPosterUrl(content)}
+												alt={content.name}
+												class="w-full h-full object-cover"
+												on:error={(e) => {
+													e.currentTarget.src = PLACEHOLDER_POSTER;
+												}}
+											/>
+										</div>
+										<div class="p-3">
+											<h3 class="font-semibold text-gray-900 text-sm truncate" title={content.name}>
+												{content.name}
+											</h3>
+											<div class="flex items-center justify-between mt-1">
+												<span class="text-xs text-gray-500">{content.year || 'N/A'}</span>
+												<span
+													class="text-xs px-2 py-0.5 rounded-full {content.content_type === 'movie'
+														? 'bg-purple-100 text-purple-700'
+														: 'bg-blue-100 text-blue-700'}"
+												>
+													{content.content_type === 'movie' ? 'Movie' : 'Series'}
+												</span>
+											</div>
+											<p class="text-xs text-gray-400 mt-2">
+												Added {formatDate(item.created_at)}
+											</p>
+										</div>
+									</a>
+									<!-- Remove button (appears on hover) -->
+									<div
+										class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+									>
+										<WatchlistButton
+											type="content"
+											id={content.tvdb_id}
+											compact={true}
+											on:removed={handleRemoved}
+										/>
+									</div>
+								</div>
+							{/if}
+						{/each}
+					</div>
+				{:else}
+					<!-- Person Grid (Actors or Directors) -->
+					<div
+						class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4"
+					>
+						{#each currentItems as item}
+							{@const person = item.person}
+							{#if person}
+								<div class="group relative">
+									<a
+										href="/person/{person.tvdb_id}"
+										class="block bg-white rounded-lg shadow hover:shadow-lg transition-shadow text-center"
+									>
+										<div class="aspect-square bg-gray-200 rounded-t-lg overflow-hidden">
+											<img
+												src={getPersonImage(person)}
+												alt={person.full_name}
+												class="w-full h-full object-cover"
+												on:error={(e) => {
+													e.currentTarget.src = PLACEHOLDER_PERSON;
+												}}
+											/>
+										</div>
+										<div class="p-3">
+											<h3
+												class="font-semibold text-gray-900 text-sm truncate"
+												title={person.full_name}
+											>
+												{person.full_name}
+											</h3>
+											{#if item.person_role_filter && item.person_role_filter !== 'any'}
+												<span class="text-xs text-indigo-600 capitalize">
+													{item.person_role_filter}
+												</span>
+											{/if}
+											<p class="text-xs text-gray-400 mt-2">
+												Added {formatDate(item.created_at)}
+											</p>
+										</div>
+									</a>
+									<!-- Remove button (appears on hover) -->
+									<div
+										class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+									>
+										<WatchlistButton
+											type="person"
+											id={person.tvdb_id}
+											compact={true}
+											on:removed={handleRemoved}
+										/>
+									</div>
+								</div>
+							{/if}
+						{/each}
+					</div>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## Summary

- Add watchlist functionality allowing users to track shows, movies, and people they're interested in
- Implement WatchlistItem model with support for both content (shows/movies) and person items
- Add person role filter options (any, actor, director) for targeted tracking
- Create full API with endpoints for adding, removing, updating, and checking watchlist status
- Build WatchlistButton component integrated into show and person detail pages
- Add dedicated watchlist page with tabbed view for shows/movies vs people
- Include navigation link to watchlist in main layout

## Test plan

- [ ] Run migrations: `alembic upgrade head`
- [ ] Add a show to watchlist from show detail page
- [ ] Add a person to watchlist from person detail page
- [ ] Verify items appear on /watchlist page
- [ ] Test removing items from watchlist
- [ ] Test person role filter functionality
- [ ] Run `make test` - all tests pass
- [ ] Run `make lint` - no linting errors