### PR TITLE
Fix cast display showing character name instead of content title

### DIFF
--- a/backend/app/tasks/watchlist_updates.py
+++ b/backend/app/tasks/watchlist_updates.py
@@ -7,11 +7,31 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from app.db.database import SyncSessionLocal
-from app.models import Content, WatchlistItem, Season, Episode, Person, Credit, WatchlistPersonSnapshot, WatchlistContentSnapshot
+from app.models import Content, WatchlistItem, Season, Episode, Person, WatchlistPersonSnapshot, WatchlistContentSnapshot
 from app.models.watchlist import PersonRoleFilter
 from app.models.watchlist_update import WatchlistUpdate, UpdateType
 from app.services.tvdb import tvdb_service
 from app.workers.celery_app import celery_app
+
+
+def parse_character_credit(char: dict[str, Any]) -> tuple[str, str]:
+    """
+    Parse a character/credit dict from TVDB API to extract content and character names.
+
+    Args:
+        char: A character dict from TVDB API containing fields like
+              seriesName, movieName, name (character), personName.
+
+    Returns:
+        Tuple of (content_name, character_name).
+        content_name is the series/movie title, or "Unknown Project" if unavailable.
+        character_name is the character name, or empty string if unavailable.
+    """
+    # Get content name - only use series/movie name, never fall back to character name
+    content_name = char.get("seriesName") or char.get("movieName") or "Unknown Project"
+    # Get character name
+    character_name = char.get("name") or char.get("personName") or ""
+    return content_name, character_name
 
 
 @celery_app.task(bind=True, max_retries=3)
@@ -349,8 +369,7 @@ def _check_person_for_updates(db, person: Person, watchlist_items: list[Watchlis
             credit_key = (content_tvdb_id, "actor")
             if credit_key not in known_credit_keys:
                 # New acting role found for this user
-                content_name = char.get("seriesName") or char.get("movieName") or char.get("name") or "Unknown Project"
-                character_name = char.get("name") or char.get("personName") or ""
+                content_name, character_name = parse_character_credit(char)
 
                 new_roles_for_user += 1
                 print(f"        → NEW ROLE: {content_name}")

--- a/backend/app/tasks/watchlist_updates.py
+++ b/backend/app/tasks/watchlist_updates.py
@@ -14,7 +14,7 @@ from app.services.tvdb import tvdb_service
 from app.workers.celery_app import celery_app
 
 
-def parse_character_credit(char: dict[str, Any]) -> tuple[str, str]:
+def parse_character_credit(char: dict[str, Any]) -> tuple[str | None, str]:
     """
     Parse a character/credit dict from TVDB API to extract content and character names.
 
@@ -24,14 +24,46 @@ def parse_character_credit(char: dict[str, Any]) -> tuple[str, str]:
 
     Returns:
         Tuple of (content_name, character_name).
-        content_name is the series/movie title, or "Unknown Project" if unavailable.
+        content_name is the series/movie title, or None if not in the API response.
         character_name is the character name, or empty string if unavailable.
     """
     # Get content name - only use series/movie name, never fall back to character name
-    content_name = char.get("seriesName") or char.get("movieName") or "Unknown Project"
+    content_name = char.get("seriesName") or char.get("movieName") or None
     # Get character name
     character_name = char.get("name") or char.get("personName") or ""
     return content_name, character_name
+
+
+def _lookup_content_name(db, content_tvdb_id: int, is_series: bool) -> str | None:
+    """
+    Look up content name from DB or TVDB API.
+
+    Args:
+        db: Database session
+        content_tvdb_id: The TVDB ID of the series or movie
+        is_series: True if this is a series, False if movie
+
+    Returns:
+        The content name, or None if not found anywhere.
+    """
+    # First check local DB
+    stmt = select(Content).where(Content.tvdb_id == content_tvdb_id)
+    result = db.execute(stmt)
+    content = result.scalar_one_or_none()
+    if content and content.name:
+        return content.name
+
+    # Not in DB, fetch from TVDB API
+    if is_series:
+        api_data = tvdb_service.get_series_details(content_tvdb_id)
+        if api_data:
+            return api_data.get("name")
+    else:
+        api_data = tvdb_service.get_movie_details(content_tvdb_id)
+        if api_data:
+            return api_data.get("name")
+
+    return None
 
 
 @celery_app.task(bind=True, max_retries=3)
@@ -370,6 +402,12 @@ def _check_person_for_updates(db, person: Person, watchlist_items: list[Watchlis
             if credit_key not in known_credit_keys:
                 # New acting role found for this user
                 content_name, character_name = parse_character_credit(char)
+
+                # If API didn't include content name, look it up
+                if not content_name:
+                    content_name = _lookup_content_name(
+                        db, content_tvdb_id, is_series=bool(series_id)
+                    ) or "Unknown Project"
 
                 new_roles_for_user += 1
                 print(f"        → NEW ROLE: {content_name}")

--- a/backend/scripts/fix_cast_update_descriptions.py
+++ b/backend/scripts/fix_cast_update_descriptions.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Script to fix watchlist update descriptions where the character name was
+incorrectly used as the content title.
+
+Bug: When TVDB API returned character data without seriesName or movieName,
+the code fell back to char.get("name") which is the character name. This caused
+descriptions like "Dulé Hill cast in 'David' as David".
+
+This script finds affected records and fixes them by looking up the correct
+content name from the database or TVDB API.
+"""
+
+import asyncio
+import sys
+
+# Add the app to path
+sys.path.insert(0, "/Users/swm/Code/whatisonthe.tv/backend")
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker, selectinload
+
+from app.core.config import settings
+from app.models import Content
+from app.models.watchlist_update import WatchlistUpdate, UpdateType
+from app.services.tvdb import tvdb_service
+
+
+async def fix_cast_update_descriptions(dry_run: bool = True):
+    """
+    Find and fix watchlist updates where character name was used as content name.
+
+    Args:
+        dry_run: If True, only report what would be changed without making changes.
+    """
+    print("=" * 60)
+    print("FIX CAST UPDATE DESCRIPTIONS")
+    print(f"Mode: {'DRY RUN' if dry_run else 'LIVE'}")
+    print("=" * 60)
+
+    # Create async engine
+    engine = create_async_engine(settings.database_url)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as db:
+        # Find all NEW_CAST updates
+        stmt = (
+            select(WatchlistUpdate)
+            .where(WatchlistUpdate.update_type == UpdateType.NEW_CAST)
+            .options(selectinload(WatchlistUpdate.watchlist_item))
+        )
+        result = await db.execute(stmt)
+        updates = result.scalars().all()
+
+        print(f"\nFound {len(updates)} NEW_CAST updates to check")
+
+        fixed_count = 0
+        skipped_count = 0
+
+        for update in updates:
+            details = update.details or {}
+            content_name = details.get("content_name")
+            character_name = details.get("character_name")
+            content_tvdb_id = details.get("content_tvdb_id")
+
+            # Check if this record has the bug:
+            # content_name equals character_name (case-insensitive)
+            if not content_name or not character_name:
+                continue
+
+            if content_name.lower() != character_name.lower():
+                continue
+
+            # This record likely has the bug - look up the correct name
+            print(f"\n  Found affected record (id={update.id}):")
+            print(f"    Current description: {update.description}")
+            print(f"    content_name: {content_name}")
+            print(f"    character_name: {character_name}")
+            print(f"    content_tvdb_id: {content_tvdb_id}")
+
+            if not content_tvdb_id:
+                print("    SKIP: No content_tvdb_id to look up")
+                skipped_count += 1
+                continue
+
+            # Look up correct name from DB first
+            correct_name = None
+            stmt = select(Content).where(Content.tvdb_id == content_tvdb_id)
+            result = await db.execute(stmt)
+            content = result.scalar_one_or_none()
+
+            if content and content.name:
+                correct_name = content.name
+                print(f"    Found in DB: {correct_name}")
+            else:
+                # Try TVDB API - determine if series or movie from role_type or other hints
+                # First try series, then movie
+                print("    Not in DB, trying TVDB API...")
+                api_data = tvdb_service.get_series_details(content_tvdb_id)
+                if api_data and api_data.get("name"):
+                    correct_name = api_data.get("name")
+                    print(f"    Found series: {correct_name}")
+                else:
+                    api_data = tvdb_service.get_movie_details(content_tvdb_id)
+                    if api_data and api_data.get("name"):
+                        correct_name = api_data.get("name")
+                        print(f"    Found movie: {correct_name}")
+
+            if not correct_name:
+                print("    SKIP: Could not find correct name")
+                skipped_count += 1
+                continue
+
+            # Build corrected description
+            # Extract person name from the original description
+            # Format: '{person_name} cast in "{content_name}"' or with ' as {character}'
+            old_desc = update.description
+
+            # Try to extract person name - it's everything before ' cast in '
+            if ' cast in "' in old_desc:
+                person_name = old_desc.split(' cast in "')[0]
+                new_desc = f'{person_name} cast in "{correct_name}"'
+                if character_name and character_name != person_name:
+                    new_desc += f' as {character_name}'
+
+                print(f"    New description: {new_desc}")
+
+                if not dry_run:
+                    # Update the record
+                    update.description = new_desc
+                    update.details = {
+                        **details,
+                        "content_name": correct_name,
+                    }
+                    fixed_count += 1
+            else:
+                print("    SKIP: Unexpected description format")
+                skipped_count += 1
+
+        if not dry_run:
+            await db.commit()
+
+        print("\n" + "=" * 60)
+        print("SUMMARY")
+        print(f"  Records checked: {len(updates)}")
+        print(f"  Records {'would be ' if dry_run else ''}fixed: {fixed_count}")
+        print(f"  Records skipped: {skipped_count}")
+        if dry_run:
+            print("\nRun with --live to apply changes")
+        print("=" * 60)
+
+
+if __name__ == "__main__":
+    dry_run = "--live" not in sys.argv
+
+    if not dry_run:
+        print("\n*** LIVE MODE - Changes will be saved ***\n")
+        confirm = input("Are you sure? (yes/no): ")
+        if confirm.lower() != "yes":
+            print("Aborted.")
+            sys.exit(0)
+
+    asyncio.run(fix_cast_update_descriptions(dry_run=dry_run))

--- a/backend/tests/tasks/__init__.py
+++ b/backend/tests/tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for task modules."""

--- a/backend/tests/tasks/test_watchlist_updates.py
+++ b/backend/tests/tasks/test_watchlist_updates.py
@@ -42,8 +42,8 @@ class TestParseCharacterCredit:
             "name": "David",  # This is the character name
         }
         content_name, character_name = parse_character_credit(char)
-        # content_name should be "Unknown Project", NOT "David"
-        assert content_name == "Unknown Project"
+        # content_name should be None (to trigger DB/API lookup), NOT "David"
+        assert content_name is None
         assert character_name == "David"
 
     def test_prefers_series_name_over_movie_name(self):
@@ -68,14 +68,17 @@ class TestParseCharacterCredit:
         content_name, character_name = parse_character_credit(char)
         assert content_name == "The Movie"
 
-    def test_unknown_project_when_both_names_missing(self):
-        """Returns 'Unknown Project' when both series and movie names are missing."""
+    def test_returns_none_when_both_names_missing(self):
+        """Returns None for content_name when both series and movie names are missing.
+
+        The caller is responsible for looking up the name from DB/API.
+        """
         char = {
             "seriesId": 12345,
             "name": "Character",
         }
         content_name, character_name = parse_character_credit(char)
-        assert content_name == "Unknown Project"
+        assert content_name is None
 
     def test_uses_person_name_as_character_fallback(self):
         """Falls back to personName for character when name is missing."""

--- a/backend/tests/tasks/test_watchlist_updates.py
+++ b/backend/tests/tasks/test_watchlist_updates.py
@@ -1,0 +1,97 @@
+"""Tests for watchlist updates task module."""
+
+from app.tasks.watchlist_updates import parse_character_credit
+
+
+class TestParseCharacterCredit:
+    """Tests for parse_character_credit helper function."""
+
+    def test_extracts_series_name_when_present(self):
+        """Series name should be used for content_name when available."""
+        char = {
+            "seriesId": 12345,
+            "seriesName": "Psych",
+            "name": "Gus",
+        }
+        content_name, character_name = parse_character_credit(char)
+        assert content_name == "Psych"
+        assert character_name == "Gus"
+
+    def test_extracts_movie_name_when_present(self):
+        """Movie name should be used for content_name when available."""
+        char = {
+            "movieId": 67890,
+            "movieName": "Holes",
+            "name": "Sam",
+        }
+        content_name, character_name = parse_character_credit(char)
+        assert content_name == "Holes"
+        assert character_name == "Sam"
+
+    def test_does_not_use_character_name_for_content_name(self):
+        """
+        Bug fix test: When seriesName and movieName are missing,
+        content_name should NOT fall back to the character name.
+
+        This was the bug: "Dulé Hill cast in 'David' as David" - where
+        the character name 'David' was incorrectly used as the content title.
+        """
+        char = {
+            "seriesId": 12345,
+            # seriesName is missing!
+            "name": "David",  # This is the character name
+        }
+        content_name, character_name = parse_character_credit(char)
+        # content_name should be "Unknown Project", NOT "David"
+        assert content_name == "Unknown Project"
+        assert character_name == "David"
+
+    def test_prefers_series_name_over_movie_name(self):
+        """Series name takes precedence over movie name."""
+        char = {
+            "seriesId": 12345,
+            "seriesName": "The Series",
+            "movieId": 67890,
+            "movieName": "The Movie",
+            "name": "Character",
+        }
+        content_name, character_name = parse_character_credit(char)
+        assert content_name == "The Series"
+
+    def test_uses_movie_name_when_series_name_missing(self):
+        """Falls back to movie name when series name is missing."""
+        char = {
+            "movieId": 67890,
+            "movieName": "The Movie",
+            "name": "Character",
+        }
+        content_name, character_name = parse_character_credit(char)
+        assert content_name == "The Movie"
+
+    def test_unknown_project_when_both_names_missing(self):
+        """Returns 'Unknown Project' when both series and movie names are missing."""
+        char = {
+            "seriesId": 12345,
+            "name": "Character",
+        }
+        content_name, character_name = parse_character_credit(char)
+        assert content_name == "Unknown Project"
+
+    def test_uses_person_name_as_character_fallback(self):
+        """Falls back to personName for character when name is missing."""
+        char = {
+            "seriesId": 12345,
+            "seriesName": "The Show",
+            "personName": "Actor Name",
+        }
+        content_name, character_name = parse_character_credit(char)
+        assert character_name == "Actor Name"
+
+    def test_empty_character_when_no_names_available(self):
+        """Returns empty string for character when no name fields present."""
+        char = {
+            "seriesId": 12345,
+            "seriesName": "The Show",
+        }
+        content_name, character_name = parse_character_credit(char)
+        assert character_name == ""


### PR DESCRIPTION
## Summary

- **Bug**: When showing new cast notifications, the description incorrectly displayed the character name where the show/movie title should be (e.g., "Dulé Hill cast in 'David' as David" instead of "Dulé Hill cast in 'Psych' as Gus")
- **Root cause**: The fallback chain for `content_name` included `char.get("name")` which is the character name, not the content title
- **Fix**: Extract parsing logic into `parse_character_credit()` helper that only uses `seriesName` or `movieName` for the content title
- **Fallback**: When API doesn't include the name, look it up from our DB or TVDB API
- **Migration**: Added script to fix existing affected records

## Changes

1. `backend/app/tasks/watchlist_updates.py`:
   - Added `parse_character_credit()` helper to properly parse API response
   - Added `_lookup_content_name()` to fetch from DB/API when missing
   - Fixed the description building to never use character name as title

2. `backend/tests/tasks/test_watchlist_updates.py`:
   - Added 8 unit tests covering all edge cases

3. `backend/scripts/fix_cast_update_descriptions.py`:
   - One-time script to fix existing records in the database

## Fixing existing data

After deploying, run the script to fix existing records:

```bash
# Dry run first to see what would be changed
python scripts/fix_cast_update_descriptions.py

# Apply fixes
python scripts/fix_cast_update_descriptions.py --live
```

## Test plan

- [x] Added 8 unit tests for `parse_character_credit()` covering all edge cases
- [x] All 44 backend tests pass
- [x] All 72 frontend tests pass
- [x] Lint passes on changed files
- [x] Security scan passes

🤖 Generated with [Claude Code](https://claude.ai/code)